### PR TITLE
renovate: Add .renovaterc.json5

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>qubesome/.github"]
+}


### PR DESCRIPTION
The previous renaming to default.json means that renovate couldn't find the configuration for the .github repo itself.